### PR TITLE
Implement bot script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DISCORD_TOKEN=seu_token_de_bot
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/ID/TOKEN
+SERVER_API=https://api-server.lyrahost.com.br/ID/TOKEN/
+INTERVAL_MINUTES=5

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ O bot irá:
 3. Postar no webhook definido em `DISCORD_WEBHOOK_URL` a cada `INTERVAL_MINUTES`.
 
 
+## Agendamento
+
+Defina `INTERVAL_MINUTES` no arquivo `.env` para determinar o intervalo (em minutos) entre as verificações do servidor e os envios para o Discord. O valor padrão é 5 minutos.
+
+
 ## Contribuição
 
 1. Fork este repositório.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const https = require('https');
+const { URL } = require('url');
+
+function loadEnv() {
+  if (fs.existsSync('.env')) {
+    const env = fs.readFileSync('.env', 'utf8');
+    env.split(/\r?\n/).forEach(line => {
+      const match = line.match(/^([^=#]+)=(.*)$/);
+      if (match) {
+        const key = match[1].trim();
+        const val = match[2].trim();
+        if (!process.env[key]) {
+          process.env[key] = val;
+        }
+      }
+    });
+  }
+}
+
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    const options = new URL(url);
+    https.get(options, res => {
+      let data = '';
+      res.on('data', chunk => (data += chunk));
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch {
+          resolve({ raw: data });
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+function postJSON(url, body) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const options = {
+      method: 'POST',
+      hostname: u.hostname,
+      path: u.pathname + u.search,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body)
+      }
+    };
+
+    const req = https.request(options, res => {
+      res.on('data', () => {});
+      res.on('end', resolve);
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+async function connectDiscord() {
+  if (!process.env.DISCORD_TOKEN) return;
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'discord.com',
+      path: '/api/users/@me',
+      method: 'GET',
+      headers: { Authorization: `Bot ${process.env.DISCORD_TOKEN}` }
+    };
+    const req = https.request(options, res => {
+      if (res.statusCode === 200) resolve();
+      else reject(new Error(`Discord auth failed: ${res.statusCode}`));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function run() {
+  loadEnv();
+
+  const {
+    DISCORD_TOKEN,
+    DISCORD_WEBHOOK_URL,
+    SERVER_API,
+    INTERVAL_MINUTES
+  } = process.env;
+
+  if (!DISCORD_WEBHOOK_URL || !SERVER_API) {
+    console.error('Configure DISCORD_WEBHOOK_URL e SERVER_API');
+    return;
+  }
+
+  try {
+    await connectDiscord();
+    console.log('Conectado ao Discord');
+  } catch (err) {
+    console.error('Erro ao conectar ao Discord:', err.message);
+  }
+
+  const interval = (parseInt(INTERVAL_MINUTES, 10) || 5) * 60 * 1000;
+
+  async function tick() {
+    try {
+      const status = await fetchJSON(SERVER_API);
+      const content = `Status do servidor: ${JSON.stringify(status)}`;
+      await postJSON(DISCORD_WEBHOOK_URL, JSON.stringify({ content }));
+      console.log('Enviado:', content);
+    } catch (err) {
+      console.error('Erro ao enviar webhook:', err.message);
+    }
+  }
+
+  tick();
+  setInterval(tick, interval);
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "discord-api",
+  "version": "1.0.0",
+  "description": "Bot para integrar status do servidor com Discord via Webhook",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add example environment file
- implement Node.js bot to fetch server status and post to a Discord webhook
- describe scheduling in README

## Testing
- `npm test` *(fails: Missing script)*
- `DISCORD_WEBHOOK_URL=https://example.com/webhook SERVER_API=https://example.com/status INTERVAL_MINUTES=0.001 node index.js` *(fails to send due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688682778e3c8329935b0c440d8f78ce